### PR TITLE
fix(config): Declare proper `.package.contributes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,35 +33,9 @@
 		"url": "https://github.com/MrSilaz/typo3snippets.git"
 	},
 	"contributes": {
-		"languages": [
-			{
-				"id": "typoscript",
-				"aliases": [
-					"TypoScript",
-					"typoscript"
-				],
-				"extensions": [
-					".ts",
-					".t3",
-					".fluid"
-				]
-			}
-		],
 		"snippets": [
 			{
-				"language": "html",
-				"path": "./snippets/typoscript.json"
-			},
-			{
 				"language": "typoscript",
-				"path": "./snippets/typoscript.json"
-			},
-			{
-				"language": "typescript",
-				"path": "./snippets/typoscript.json"
-			},
-			{
-				"language": "plaintext",
 				"path": "./snippets/typoscript.json"
 			},
 			{


### PR DESCRIPTION
# Contents of this PR:

The former declarations used a somewhat shotgut approach and:

- declared language features the extension does not actually provide.
- caused the extension  to hog the `.ts` extension,
  which belongs to typescript.
- added a non-standard `.t3` file extension.
  (Use `.typoscript` or `.tsconfig` accordingly.)
- added a non-standard `.fluid` file extension.
  (Use `.html` accordingly.)
- added TypoScript snippets to HTML contexts.
- added TypoScript snippets to TypeScript contexts.
- added TypoScript snippets to plain text contexts.

These shortcomings are repaired.

This PR fixes #2.